### PR TITLE
Made the Script More Portable by Changing `ENV_VAR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rtb-wrapper - declarative rsync-time-backup [![Build Status](https://travis-ci.org/thomas-mc-work/rtb-wrapper.svg?branch=master)](https://travis-ci.org/thomas-mc-work/rtb-wrapper)
 
 You know and love the well known __[rsync-time-backup](https://github.com/laurent22/rsync-time-backup)__ from
-[Laurent Cozic aka laurent22](https://github.com/laurent22)! Now what could be missing since this is a mature 
+[Laurent Cozic aka laurent22](https://github.com/laurent22)! Now what could be missing since this is a mature
 project? The whole thing based on separate profile files per backup case!
 
 __Example:__
@@ -14,7 +14,7 @@ Consider this example __profile__ (named `user1-documents.inc`):
 
 Now it's as easy as this to __backup__ our data:
 
-    rtb-wrapper.sh backup user1-documents 
+    rtb-wrapper.sh backup user1-documents
 
 And here is how to __restore__ from the `latest` backup:
 
@@ -36,7 +36,7 @@ And here is how to __restore__ from the `latest` backup:
 
 ## Configuration
 
-`rtb-wrapper` is using `$HOME/.rsync_tmbackup` as the base config folder, except it's overridden by the environment variable `CONFIG_DIR`.
+`rtb-wrapper` is using `$HOME/.rsync_tmbackup` as the base config folder, except it's overridden by the environment variable `RTB_CONFIG_DIR`.
 
 ### Profile file
 

--- a/rtb-wrapper.sh
+++ b/rtb-wrapper.sh
@@ -20,24 +20,24 @@ fn_create_backup_cmd () {
     cmd="rsync_tmbackup.sh '${SOURCE}' '${TARGET}'"
 
     exclude_file_check=${EXCLUDE_FILE:-}
-    
+
     if [ ! -z "${exclude_file_check}" ]; then
         cmd="${cmd} '${EXCLUDE_FILE}'"
     fi
-    
+
     echo "$cmd"
 }
 
 # create restore cli command
 fn_create_restore_cmd () {
     cmd="rsync -aP"
-    
+
     if [ "${WIPE_SOURCE_ON_RESTORE:-'false'}" = "true" ]; then
         cmd="${cmd} --delete"
     fi
-    
+
     cmd="${cmd} '${TARGET}/latest/' '${SOURCE}/'"
-    
+
     echo "$cmd"
 }
 
@@ -59,7 +59,7 @@ action=${1?"param 1: action: backup, restore"}
 profile=${2?"param 2: name of the profile"}
 
 # load config
-config_dir=${CONFIG_DIR:-"${HOME}/.rsync_tmbackup"}
+config_dir=${RTB_CONFIG_DIR:-"${HOME}/.rsync_tmbackup"}
 
 # load profile
 profile_dir="${config_dir}/conf.d"


### PR DESCRIPTION
The environment variable of `CONFIG_DIR` is, unfortunately, a very non-portable variable requirement. 

I know when I started learning linux, either plenty of "how to" sites would be lazy and always suggest `CONFIG_DIR` as a generic, exportable variable. Or, even worse, no one explains what it means or you can use any combo of characters. 

Therefore, utilizing this generic variable is, at best, a feature that will forever go unused or changed on a personal repo. At worse, it can potentially screw up a users system.

Thanks